### PR TITLE
Fix Block Aimer Bug

### DIFF
--- a/src/Actors/BlockPlacement.gd
+++ b/src/Actors/BlockPlacement.gd
@@ -100,4 +100,7 @@ func _snap_vector_to_grid(vec) -> Vector2:
 
 func _snap_float_to_grid(value) -> float:
 	var remainder := fmod(value, BlockSize)
-	return value - remainder
+	if value >= 0.0:
+		return value - remainder
+	else:
+		return value - (BlockSize + remainder)


### PR DESCRIPTION
There was a bug that would happen if you went too far left on the map (into negative `x` values)

The snap would put blocks one grid cell to the right of where they should've been

This was the result of arithmetic with negative numbers

Resolved by having different arithmetic for the snapping when the number is negative
