### PR TITLE
Change Weather Rates and Make Lava Non-Destructive

### DIFF
--- a/src/Main/Game.tscn
+++ b/src/Main/Game.tscn
@@ -99,7 +99,15 @@ stream = ExtResource( 8 )
 [node name="PauseMenu" parent="InterfaceLayer" instance=ExtResource( 1 )]
 
 [node name="WeatherTimer" type="Timer" parent="."]
-wait_time = 40.0
+wait_time = 20.0
+one_shot = true
+autostart = true
+
+[node name="EruptionTimer" type="Timer" parent="."]
+wait_time = 5.0
+
+[node name="InitialEruptionDelay" type="Timer" parent="."]
+wait_time = 30.0
 one_shot = true
 autostart = true
 
@@ -121,3 +129,5 @@ volume_db = 13.109
 [connection signal="timeout" from="InterfaceLayer/WeatherAlert/Timer" to="InterfaceLayer/WeatherAlert" method="_on_Timer_timeout"]
 [connection signal="finished" from="InterfaceLayer/WeatherAlert/AudioStreamPlayer" to="InterfaceLayer/WeatherAlert" method="_on_AudioStreamPlayer_finished"]
 [connection signal="timeout" from="WeatherTimer" to="." method="_on_WeatherTimer_timeout"]
+[connection signal="timeout" from="EruptionTimer" to="." method="_on_EruptionTimer_timeout"]
+[connection signal="timeout" from="InitialEruptionDelay" to="." method="_on_InitialEruptionDelay_timeout"]

--- a/src/Weather/Eruption.gd
+++ b/src/Weather/Eruption.gd
@@ -26,5 +26,6 @@ func start() -> Array:
 			var lava_piece = lava_piece_scene.instance()
 			lava_piece.position = Vector2(rand_range(limit_left, limit_right), rand_range(limit_top, limit_top - (STAGGER_BETWEEN_WAVES * wave_number)))
 			lava_pieces.append(lava_piece)
-	magnitude += 1 # Next time, the intensity will be greater
+	# Trying consistent magnitude and less destructive
+#	magnitude += 1 # Next time, the intensity will be greater
 	return lava_pieces

--- a/src/Weather/LavaPiece.gd
+++ b/src/Weather/LavaPiece.gd
@@ -13,18 +13,20 @@ func _on_RigidBody2D_body_entered(body):
 	if body.name == 'Player':
 		emit_signal("hit_player")
 		self.queue_free()
-	elif body.name == 'TileMap':
-		# break block
-		var body_position = body.world_to_map(position)
-		body.set_cell(body_position.x,body_position.y+1,-1)
-		body.set_cell(body_position.x-1,body_position.y+1,-1)
-		body.set_cell(body_position.x+1,body_position.y+1,-1)
-		if randi() % coin_probability_denominator == 0:
-			emit_signal("place_coin", position)
-		self.queue_free()
-	else:
-		# breaking player placed blocks
-		body.queue_free()
-		if randi() % coin_probability_denominator == 0:
-			emit_signal("place_coin", position)
-		self.queue_free()
+	# Trying Lava Pieces to be non-destructive (but more frequent)
+#	elif body.name == 'TileMap':
+#		# break block
+#		var body_position = body.world_to_map(position)
+#		body.set_cell(body_position.x,body_position.y+1,-1)
+#		body.set_cell(body_position.x-1,body_position.y+1,-1)
+#		body.set_cell(body_position.x+1,body_position.y+1,-1)
+#		if randi() % coin_probability_denominator == 0:
+#			emit_signal("place_coin", position)
+#		self.queue_free()
+#	else:
+#		# breaking player placed blocks
+#		body.queue_free()
+#		if randi() % coin_probability_denominator == 0:
+#			emit_signal("place_coin", position)
+#		self.queue_free()
+	self.queue_free()

--- a/src/Weather/LavaPiece.tscn
+++ b/src/Weather/LavaPiece.tscn
@@ -54,7 +54,7 @@ script = ExtResource( 2 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 9 )
-frame = 3
+frame = 2
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]


### PR DESCRIPTION
Making some pretty fundamental changes - here's my thinking:

I feel like right now, the player doesn't have much incentive to build a structure - it's easy to just hide right before a storm and otherwise just lay blocks down to navigate from here to there.

It's not worth the player's time to build anything because it's too hard to build anything sustainable (the eruptions will tear it apart) and it's easier to just hide when it comes.

So the changes I'm making here are as follows:
* Eruptions are non-descructive (so the player doesn't give up on building)
* Eruptions are much more frequent (5s) but not escalating - so there's a constant threat (and reason to build shelter)
* Make earthquakes just a little more frequent (cause _some_ havoc to what the player builds) and increase the pace of the game

We can tweak these numbers of revert this completely, but I thought this was worth a try
